### PR TITLE
update tmp-li-case to not always enable embroider

### DIFF
--- a/transforms/ember-cli-build/__testfixtures__/already-migrated.output.js
+++ b/transforms/ember-cli-build/__testfixtures__/already-migrated.output.js
@@ -20,6 +20,14 @@ module.exports = function (defaults) {
   const { compatAdapters } = require('@linkedin/pemberly-embroider/src');
   const adapters = compatAdapters();
 
+  // Making sure to use classic build when not running embroider test scenarios.
+  // maybeEmbroider turns on Embroider when @embroider/core is installed, and
+  // we have to install @embroider/core because it's a peerDep of
+  // @embroider/compat, which is a peerDep of @linkedin/pemberly-embroider.
+  if (!process.env.EMBROIDER_TEST_SETUP_OPTIONS) {
+    return app.toTree();
+  }
+
   return maybeEmbroider(app, {
     compatAdapters: new Map(adapters),
   });

--- a/transforms/ember-cli-build/__testfixtures__/basic.output.js
+++ b/transforms/ember-cli-build/__testfixtures__/basic.output.js
@@ -20,6 +20,14 @@ module.exports = function (defaults) {
   const { compatAdapters } = require('@linkedin/pemberly-embroider/src');
   const adapters = compatAdapters();
 
+  // Making sure to use classic build when not running embroider test scenarios.
+  // maybeEmbroider turns on Embroider when @embroider/core is installed, and
+  // we have to install @embroider/core because it's a peerDep of
+  // @embroider/compat, which is a peerDep of @linkedin/pemberly-embroider.
+  if (!process.env.EMBROIDER_TEST_SETUP_OPTIONS) {
+    return app.toTree();
+  }
+
   return maybeEmbroider(app, {
     compatAdapters: new Map(adapters),
   });

--- a/transforms/ember-cli-build/__testfixtures__/const-assignment.output.js
+++ b/transforms/ember-cli-build/__testfixtures__/const-assignment.output.js
@@ -20,6 +20,14 @@ module.exports = function (defaults) {
   const { compatAdapters } = require('@linkedin/pemberly-embroider/src');
   const adapters = compatAdapters();
 
+  // Making sure to use classic build when not running embroider test scenarios.
+  // maybeEmbroider turns on Embroider when @embroider/core is installed, and
+  // we have to install @embroider/core because it's a peerDep of
+  // @embroider/compat, which is a peerDep of @linkedin/pemberly-embroider.
+  if (!process.env.EMBROIDER_TEST_SETUP_OPTIONS) {
+    return app.toTree();
+  }
+
   return maybeEmbroider(app, {
     compatAdapters: new Map(adapters),
   });

--- a/transforms/ember-cli-build/__testfixtures__/different-assignment.output.js
+++ b/transforms/ember-cli-build/__testfixtures__/different-assignment.output.js
@@ -13,6 +13,14 @@ module.exports = function (defaults) {
   const { compatAdapters } = require('@linkedin/pemberly-embroider/src');
   const adapters = compatAdapters();
 
+  // Making sure to use classic build when not running embroider test scenarios.
+  // maybeEmbroider turns on Embroider when @embroider/core is installed, and
+  // we have to install @embroider/core because it's a peerDep of
+  // @embroider/compat, which is a peerDep of @linkedin/pemberly-embroider.
+  if (!process.env.EMBROIDER_TEST_SETUP_OPTIONS) {
+    return app.toTree();
+  }
+
   return maybeEmbroider(foo, {
     compatAdapters: new Map(adapters),
   });

--- a/transforms/ember-cli-build/__testfixtures__/without-comment.output.js
+++ b/transforms/ember-cli-build/__testfixtures__/without-comment.output.js
@@ -13,6 +13,14 @@ module.exports = function (defaults) {
   const { compatAdapters } = require('@linkedin/pemberly-embroider/src');
   const adapters = compatAdapters();
 
+  // Making sure to use classic build when not running embroider test scenarios.
+  // maybeEmbroider turns on Embroider when @embroider/core is installed, and
+  // we have to install @embroider/core because it's a peerDep of
+  // @embroider/compat, which is a peerDep of @linkedin/pemberly-embroider.
+  if (!process.env.EMBROIDER_TEST_SETUP_OPTIONS) {
+    return app.toTree();
+  }
+
   return maybeEmbroider(app, {
     compatAdapters: new Map(adapters),
   });

--- a/transforms/ember-cli-build/index.js
+++ b/transforms/ember-cli-build/index.js
@@ -61,6 +61,14 @@ module.exports = function transformer(file, api) {
           const { compatAdapters } = require('@linkedin/pemberly-embroider/src');
           const adapters = compatAdapters();
 
+          // Making sure to use classic build when not running embroider test scenarios.
+          // maybeEmbroider turns on Embroider when @embroider/core is installed, and
+          // we have to install @embroider/core because it's a peerDep of
+          // @embroider/compat, which is a peerDep of @linkedin/pemberly-embroider.
+          if (!process.env.EMBROIDER_TEST_SETUP_OPTIONS) {
+            return app.toTree();
+          }
+
           return maybeEmbroider(${newEmberAddon.paths()[0].value.id.name}, {
             compatAdapters: new Map(adapters),
           });
@@ -110,6 +118,14 @@ module.exports = function transformer(file, api) {
           // temporary adapters for embroider build at LI
           const { compatAdapters } = require('@linkedin/pemberly-embroider/src');
           const adapters = compatAdapters();
+
+          // Making sure to use classic build when not running embroider test scenarios.
+          // maybeEmbroider turns on Embroider when @embroider/core is installed, and
+          // we have to install @embroider/core because it's a peerDep of
+          // @embroider/compat, which is a peerDep of @linkedin/pemberly-embroider.
+          if (!process.env.EMBROIDER_TEST_SETUP_OPTIONS) {
+            return app.toTree();
+          }
 
           return maybeEmbroider(${newEmberAddon.paths()[0].value.id.name}, {
             compatAdapters: new Map(adapters),


### PR DESCRIPTION
We need to check `EMBROIDER_TEST_SETUP_OPTIONS` and turn off Embroider when not running Embroider test scenarios. `maybeEmbroider` turns on Embroider when @embroider/core is installed, and we have to install that, because it's a peerDep of `@embroider/compat`, which is a peerDep of `@linkedin/pemberly-embroider`. It kind of defeats the purpose if `maybeEmbroider` always uses Embroider.

`yarn test` passed.